### PR TITLE
fix: multi-chunk batched bucket sums folding error

### DIFF
--- a/sxt/multiexp/bucket_method/BUILD
+++ b/sxt/multiexp/bucket_method/BUILD
@@ -78,6 +78,20 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "fold_kernel",
+    test_deps = [
+        "//sxt/base/curve:example_element",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/base/curve:element",
+    ],
+)
+
+sxt_cc_component(
     name = "multiexponentiation",
     test_deps = [
         "//sxt/base/curve:example_element",

--- a/sxt/multiexp/bucket_method/BUILD
+++ b/sxt/multiexp/bucket_method/BUILD
@@ -30,6 +30,7 @@ sxt_cc_component(
     deps = [
         ":accumulation_kernel",
         ":combination_kernel",
+        ":fold_kernel",
         "//sxt/base/container:span",
         "//sxt/base/curve:element",
         "//sxt/base/device:memory_utility",

--- a/sxt/multiexp/bucket_method/fold_kernel.cc
+++ b/sxt/multiexp/bucket_method/fold_kernel.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method/fold_kernel.h"

--- a/sxt/multiexp/bucket_method/fold_kernel.h
+++ b/sxt/multiexp/bucket_method/fold_kernel.h
@@ -27,8 +27,8 @@ namespace sxt::mtxbk {
 /**
  * This kernel computes the left fold of partial bucket sums to produce the final bucket sums.
  *
- * The kernel processes an array of partial bucket sums, where each thread performs a left 
- * fold operation on a specific segment of data identified by its (bucket_index, 
+ * The kernel processes an array of partial bucket sums, where each thread performs a left
+ * fold operation on a specific segment of data identified by its (bucket_index,
  * bucket_group_index, output_index) coordinates. The fold operation combines multiple partial
  * results using element-wise addition.
  *

--- a/sxt/multiexp/bucket_method/fold_kernel.h
+++ b/sxt/multiexp/bucket_method/fold_kernel.h
@@ -1,0 +1,90 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cassert>
+
+#include "sxt/base/curve/element.h"
+
+namespace sxt::mtxbk {
+//--------------------------------------------------------------------------------------------------
+// segmented_left_fold_partial_bucket_sums
+//--------------------------------------------------------------------------------------------------
+/**
+ * This kernel computes the left fold of partial bucket sums to produce the final bucket sums.
+ *
+ * The kernel processes a multi-dimensional array of partial bucket sums, where each thread
+ * performs a left fold operation on a specific segment of data identified by its (bucket_index,
+ * bucket_group_index, output_index) coordinates. The fold operation combines multiple partial
+ * results using element-wise addition.
+ *
+ * Memory layout:
+ * - partial_bucket_sums: Array containing all partial sums, organized as multiple "folds" of data
+ *   where each fold has size out_size
+ * - out: Output array of size out_size that will contain the folded results
+ *
+ * Parameters:
+ * @param[out] out                     Destination array for the folded results
+ * @param[in]  partial_bucket_sums     Source array containing partial bucket sums to be folded
+ * @param[in]  out_size                Size of the output array (elements)
+ * @param[in]  partial_bucket_sum_size Total size of the partial bucket sums array (elements)
+ *
+ * Thread organization:
+ * - Each thread is responsible for folding one specific element
+ * - Thread coordinates: (blockIdx.x, threadIdx.x, blockIdx.y) map to (bucket_index,
+ * bucket_group_index, output_index)
+ * - The kernel should be launched with a grid of dim3(bucket_group_size, num_outputs, 1) and
+ *   blockDim of num_bucket_groups
+ *
+ * Preconditions:
+ * - partial_bucket_sum_size must be greater than 0
+ * - out_size must be greater than 0
+ * - partial_bucket_sum_size must be greater than or equal to out_size
+ * - partial_bucket_sum_size must be evenly divisible by out_size
+ */
+template <bascrv::element T>
+__global__ void segmented_left_fold_partial_bucket_sums(T* out, T* partial_bucket_sums,
+                                                        unsigned out_size,
+                                                        unsigned partial_bucket_sum_size) {
+  assert(partial_bucket_sum_size > 0 && out_size > 0);
+  assert(partial_bucket_sum_size >= out_size);
+  assert(partial_bucket_sum_size % out_size == 0);
+
+  auto bucket_group_size = gridDim.x;
+  auto bucket_group_index = threadIdx.x;
+  auto num_bucket_groups = blockDim.x;
+  auto bucket_index = blockIdx.x;
+  auto output_index = blockIdx.y;
+
+  auto data_offset = bucket_index + bucket_group_size * bucket_group_index +
+                     bucket_group_size * num_bucket_groups * output_index;
+
+  partial_bucket_sums += data_offset;
+  out += data_offset;
+
+  auto num_of_folds = partial_bucket_sum_size / out_size;
+
+  T sum = *partial_bucket_sums;
+  partial_bucket_sums += out_size;
+  for (unsigned i = 1; i < num_of_folds; ++i) {
+    add_inplace(sum, *partial_bucket_sums);
+    partial_bucket_sums += out_size;
+  }
+
+  *out = sum;
+}
+}; // namespace sxt::mtxbk

--- a/sxt/multiexp/bucket_method/fold_kernel.h
+++ b/sxt/multiexp/bucket_method/fold_kernel.h
@@ -27,34 +27,12 @@ namespace sxt::mtxbk {
 /**
  * This kernel computes the left fold of partial bucket sums to produce the final bucket sums.
  *
- * The kernel processes a multi-dimensional array of partial bucket sums, where each thread
- * performs a left fold operation on a specific segment of data identified by its (bucket_index,
+ * The kernel processes an array of partial bucket sums, where each thread performs a left 
+ * fold operation on a specific segment of data identified by its (bucket_index, 
  * bucket_group_index, output_index) coordinates. The fold operation combines multiple partial
  * results using element-wise addition.
  *
- * Memory layout:
- * - partial_bucket_sums: Array containing all partial sums, organized as multiple "folds" of data
- *   where each fold has size out_size
- * - out: Output array of size out_size that will contain the folded results
- *
- * Parameters:
- * @param[out] out                     Destination array for the folded results
- * @param[in]  partial_bucket_sums     Source array containing partial bucket sums to be folded
- * @param[in]  out_size                Size of the output array (elements)
- * @param[in]  partial_bucket_sum_size Total size of the partial bucket sums array (elements)
- *
- * Thread organization:
- * - Each thread is responsible for folding one specific element
- * - Thread coordinates: (blockIdx.x, threadIdx.x, blockIdx.y) map to (bucket_index,
- * bucket_group_index, output_index)
- * - The kernel should be launched with a grid of dim3(bucket_group_size, num_outputs, 1) and
- *   blockDim of num_bucket_groups
- *
- * Preconditions:
- * - partial_bucket_sum_size must be greater than 0
- * - out_size must be greater than 0
- * - partial_bucket_sum_size must be greater than or equal to out_size
- * - partial_bucket_sum_size must be evenly divisible by out_size
+ * out[index] = sum(partial_bucket_sums[index + i * out_size]) for i in [0, num_of_folds)
  */
 template <bascrv::element T>
 __global__ void segmented_left_fold_partial_bucket_sums(T* out, T* partial_bucket_sums,

--- a/sxt/multiexp/bucket_method/fold_kernel.t.cc
+++ b/sxt/multiexp/bucket_method/fold_kernel.t.cc
@@ -1,0 +1,60 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method/fold_kernel.h"
+
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxbk;
+
+TEST_CASE("we can fold partial bucket sums") {
+  memmg::managed_array<bascrv::element97> partial_bucket_sums(memr::get_managed_device_resource());
+  memmg::managed_array<bascrv::element97> bucket_sums(memr::get_managed_device_resource());
+
+  SECTION("with a single bucket") {
+    partial_bucket_sums = {1u};
+    bucket_sums = {0u};
+    segmented_left_fold_partial_bucket_sums<<<1, 1>>>(bucket_sums.data(),
+                                                      partial_bucket_sums.data(), 1, 1);
+    basdv::synchronize_device();
+    REQUIRE(bucket_sums[0] == 1u);
+  }
+
+  SECTION("with multiple buckets") {
+    partial_bucket_sums = {1u, 2u, 3u};
+    bucket_sums = {0u};
+    segmented_left_fold_partial_bucket_sums<<<1, 1>>>(bucket_sums.data(),
+                                                      partial_bucket_sums.data(), 1, 3);
+    basdv::synchronize_device();
+    REQUIRE(bucket_sums[0] == 1u + 2u + 3u);
+  }
+
+  SECTION("into multiple buckets") {
+    partial_bucket_sums = {1u, 2u, 3u, 4u, 5u, 6u};
+    bucket_sums = {0u, 0u, 0u};
+    segmented_left_fold_partial_bucket_sums<<<3, 1>>>(bucket_sums.data(),
+                                                      partial_bucket_sums.data(), 3, 6);
+    basdv::synchronize_device();
+    REQUIRE(bucket_sums[0] == 1u + 4u);
+    REQUIRE(bucket_sums[1] == 2u + 5u);
+    REQUIRE(bucket_sums[2] == 3u + 6u);
+  }
+}

--- a/sxt/multiexp/bucket_method/multiexponentiation.t.cc
+++ b/sxt/multiexp/bucket_method/multiexponentiation.t.cc
@@ -200,10 +200,14 @@ TEST_CASE("we can compute multiexponentiations with exponent sequences") {
   }
 }
 
-// Max chunk size is currently 1<<20 in mtxbk::accumulate_buckets_impl
+// Max chunk size in mtxbk::accumulate_buckets_impl is currently 1<<20.
+namespace {
+constexpr size_t max_chunk_size = 1 << 20;
+}
+
 TEST_CASE("we can compute a multiexponentiation with elements over max chunk size") {
   const size_t num_outputs = 1;
-  std::array<size_t, 2> num_elements_array = {(1 << 20) + 1, (1 << 21) + 1};
+  std::array<size_t, 2> num_elements_array = {max_chunk_size + 1, max_chunk_size * 2 + 1};
 
   std::vector<const uint8_t*> exponents;
 
@@ -233,8 +237,9 @@ TEST_CASE("we can compute a multiexponentiation with elements over max chunk siz
   }
 }
 
-// Max chunk size is currently 1<<20 in mtxbk::accumulate_buckets_impl
 TEST_CASE("we can compute a multiexponentiation with multiple outputs over max chunk size") {
+  // num_outputs_array + num_elements is chosen to ensure that the total number of elements exceeds
+  // the max_chunk_size.
   std::array<size_t, 4> num_outputs_array = {1 << 3, 1 << 4, 1 << 5, 1 << 6};
   const size_t num_elements = (1 << 17) + 1;
 


### PR DESCRIPTION
# Rationale for this change
Batch commitments with elements that are represented in 32-bytes, have 256-384 elements in the sequence, and are the same length will attempt bucket method multiexponention. The bucket method has a max chunk size of `2^20`. In cases where the batch size and element length go above the max chuck size, the commitments are incorrect. For example, `batch_size = 1<<3` and `element_length = 1<<17` will return an expected result, `element_length = 1<<17 + 1` will return an unexpected result. You can see test cases that reproduce the error in commit https://github.com/spaceandtimefdn/blitzar/commit/6d6c2e4a3b1892bf6b220fd9a3a7c6ddcebed7f3.

The issue is the `mtxbk::accumulate_buckets_impl` method. In cases where the number of chunks, `num_chunks`, is greater than 1, the partial bucket sums get split by the max chunk size number of elements. After all the buckets are accumulated, the call to the `combine_partial_bucket_sums` kernel does not handle the data offset and stride calculations to account for the multi-chunk partial bucket sums array.

To solve this issue `fold_kernel` is added. The purpose of `fold_kernel` is to take the chunked partial sums and fold them into a single bucked sums array. The `fold_kernel` class performs a segmented left fold of the partial sums:
 
```out[index] = sum(partial_bucket_sums[index + i * out_size]) for i in [0, num_of_folds)```

where the 

```num_of_folds = partial_bucket_sums.size() / out.size()```.

The tests will have to be updated when the max chunk size is increased or decreased from its `1<<20` limit.

# What changes are included in this PR?
- `fold_kernel` with a `segmented_left_fold_partial_bucket_sums` method is added to the `multiexp` package with tests.
- `accumulation` with multi-chunk cases will now use `segmented_left_fold_partial_bucket_sums` when all the partial buckets are accumulated.
- Tests are added to `multieponentiation` which reproduce the error state. They add `<2 seconds` to the overall test time.

# Are these changes tested?
Yes. Also tested by replacing the `libblitzar-linux-x86_64.so` in the `blitzar-rs` and `nova` projects and confirming the failing tests pass.
